### PR TITLE
DAR-55 Filter generated outputs by mapping id

### DIFF
--- a/docs/reconciliation/platform/facade-wave1-services.md
+++ b/docs/reconciliation/platform/facade-wave1-services.md
@@ -104,6 +104,7 @@ Pilot release contract notes:
 - `create#PilotMapping` normalizes schema-flattener field paths into pilot-safe JSON ID expressions so newly-created mappings remain visible in `list#PilotMappings` and executable by the mapping-backed run flow.
 - The active pilot remains mapping-based for this release. The facade contract uses `reconciliationMappingId` rather than `ruleSetId`.
 - `run#PilotGenericDiff` is JSON-RPC friendly for `darpan-ui`; it accepts `file1Name`/`file1Text` and `file2Name`/`file2Text` instead of raw multipart `FileItem` uploads.
+- `list#PilotGeneratedOutputs` accepts optional `reconciliationMappingId` and only returns generated outputs whose stored metadata matches that mapping when the filter is provided.
 - The underlying reconciliation engine still writes a scoped JSON diff file under `runtime://tmp/reconciliation/generic/**`.
 - `get#PilotGeneratedOutput` can return that stored JSON directly or convert it to CSV on demand for the pilot UI download action.
 

--- a/service/facade/ReconciliationFacadeServices.xml
+++ b/service/facade/ReconciliationFacadeServices.xml
@@ -122,6 +122,7 @@
             location="component://darpan/src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy">
         <description>List generated pilot diff outputs within the current user scope.</description>
         <in-parameters>
+            <parameter name="reconciliationMappingId"/>
             <parameter name="query"/>
             <parameter name="pageIndex" type="Integer" default-value="0"/>
             <parameter name="pageSize" type="Integer" default-value="20"/>

--- a/src/main/groovy/darpan/facade/reconciliation/PilotReconciliationSupport.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/PilotReconciliationSupport.groovy
@@ -70,6 +70,27 @@ class PilotReconciliationSupport {
         ]
     }
 
+    static boolean matchesGeneratedOutputDescriptor(Map<String, Object> descriptor, String reconciliationMappingId, String search) {
+        String mappingIdFilter = normalize(reconciliationMappingId)
+        String descriptorMappingId = normalize(descriptor?.reconciliationMappingId)
+        if (mappingIdFilter && descriptorMappingId != mappingIdFilter) return false
+
+        String normalizedSearch = normalize(search)?.toLowerCase()
+        if (!normalizedSearch) return true
+
+        return [
+                descriptor?.fileName,
+                descriptor?.reconciliationMappingId,
+                descriptor?.mappingName,
+                descriptor?.file1Label,
+                descriptor?.file2Label,
+                descriptor?.reconciliationType
+        ].any { value ->
+            String normalizedValue = normalize(value)?.toLowerCase()
+            normalizedValue?.contains(normalizedSearch)
+        }
+    }
+
     static String deriveDownloadFileName(String sourceFileName, String requestedFormat) {
         String format = (requestedFormat ?: "").toLowerCase()
         if (!format) return sourceFileName

--- a/src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy
+++ b/src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy
@@ -6,6 +6,7 @@ import java.sql.Timestamp
 
 int page = Math.max(0, FacadeSupport.normalizeInt(pageIndex, 0))
 int size = Math.max(1, Math.min(200, FacadeSupport.normalizeInt(pageSize, 20)))
+String mappingId = FacadeSupport.normalize(reconciliationMappingId)
 String search = FacadeSupport.normalize(query)?.toLowerCase()
 
 generatedOutputs = []
@@ -20,8 +21,6 @@ if (outputDir?.exists()) {
             .findAll { File file -> file.isFile() && PilotReconciliationSupport.isSupportedOutputFile(file.name) }
             .sort { File left, File right -> Long.compare(right.lastModified(), left.lastModified()) }
             .each { File file ->
-                if (search && !file.name.toLowerCase().contains(search)) return
-
                 Map outputDocument = [:]
                 if (PilotReconciliationSupport.sourceFormatForFile(file.name) == "json") {
                     try {
@@ -31,12 +30,15 @@ if (outputDir?.exists()) {
                     }
                 }
 
-                rows.add(PilotReconciliationSupport.buildGeneratedOutputDescriptor(
+                Map<String, Object> descriptor = PilotReconciliationSupport.buildGeneratedOutputDescriptor(
                         file.name,
                         outputDocument,
                         file.length(),
                         new Timestamp(file.lastModified())
-                ))
+                )
+
+                if (!PilotReconciliationSupport.matchesGeneratedOutputDescriptor(descriptor, mappingId, search)) return
+                rows.add(descriptor)
             }
 
     int totalCount = rows.size()

--- a/src/test/groovy/darpan/facade/reconciliation/PilotReconciliationSupportTests.groovy
+++ b/src/test/groovy/darpan/facade/reconciliation/PilotReconciliationSupportTests.groovy
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import java.sql.Timestamp
 
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertIterableEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
 
@@ -82,5 +83,50 @@ class PilotReconciliationSupportTests {
         assertEquals(1L, row.onlyInFile1Count)
         assertEquals(3L, row.onlyInFile2Count)
         assertEquals(2048L, row.sizeBytes)
+    }
+
+    @Test
+    void matchesGeneratedOutputDescriptorHonorsMappingIdFilter() {
+        Map<String, Object> descriptor = [
+                fileName               : "gorjana-order-diff.json",
+                reconciliationMappingId: "GorjanaOrderReconciliation-260407095913",
+                mappingName            : "Gorjana Order Reconciliation",
+                file1Label             : "OMS",
+                file2Label             : "SHOPIFY",
+                reconciliationType     : "JSON"
+        ]
+
+        assertTrue(PilotReconciliationSupport.matchesGeneratedOutputDescriptor(
+                descriptor,
+                "GorjanaOrderReconciliation-260407095913",
+                null
+        ))
+        assertFalse(PilotReconciliationSupport.matchesGeneratedOutputDescriptor(
+                descriptor,
+                "GorjanaOrderReconciliation",
+                null
+        ))
+        assertTrue(PilotReconciliationSupport.matchesGeneratedOutputDescriptor(
+                descriptor,
+                "GorjanaOrderReconciliation-260407095913",
+                "shopify"
+        ))
+    }
+
+    @Test
+    void matchesGeneratedOutputDescriptorRejectsUnscopedLegacyOutputWhenMappingIdFilterProvided() {
+        Map<String, Object> descriptor = [
+                fileName           : "legacy-output.csv",
+                reconciliationType : "CSV",
+                mappingName        : "Gorjana Order Reconciliation",
+                reconciliationMappingId: null
+        ]
+
+        assertFalse(PilotReconciliationSupport.matchesGeneratedOutputDescriptor(
+                descriptor,
+                "GorjanaOrderReconciliation-260407095913",
+                null
+        ))
+        assertTrue(PilotReconciliationSupport.matchesGeneratedOutputDescriptor(descriptor, null, "legacy"))
     }
 }


### PR DESCRIPTION
## Summary
- filter `list#PilotGeneratedOutputs` by `reconciliationMappingId` when provided
- add descriptor matching support for scoped output history and search
- add focused tests covering mapping-id scoping behavior

## Verification
- xmllint --noout service/facade/ReconciliationFacadeServices.xml
- ./plugins/darpan-workflows/scripts/check_repo_boundary.sh service/facade/ReconciliationFacadeServices.xml src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy src/main/groovy/darpan/facade/reconciliation/PilotReconciliationSupport.groovy src/test/groovy/darpan/facade/reconciliation/PilotReconciliationSupportTests.groovy docs/reconciliation/platform/facade-wave1-services.md
- ./plugins/darpan-workflows/scripts/run_backend_checks.sh service/facade/ReconciliationFacadeServices.xml src/main/groovy/darpan/facade/reconciliation/listPilotGeneratedOutputs.groovy src/main/groovy/darpan/facade/reconciliation/PilotReconciliationSupport.groovy src/test/groovy/darpan/facade/reconciliation/PilotReconciliationSupportTests.groovy docs/reconciliation/platform/facade-wave1-services.md
- ./gradlew --no-daemon :runtime:component:darpan:test --tests darpan.facade.reconciliation.PilotReconciliationSupportTests
